### PR TITLE
Add mandatory directory for Sapper build

### DIFF
--- a/client_new/static/.gitignore
+++ b/client_new/static/.gitignore
@@ -1,0 +1,2 @@
+# Sapper needs the static folder to exist to be able to export the app.
+# This .gitignore stays here to enable us to commit the `static` directory.


### PR DESCRIPTION
## Description

Lors de la tentative de build de repo via les GitHub Actions, je me suis retrouvée avec l'erreur suivante : 
```
Error while initializing entrypoint: { Error: ENOENT: no such file or directory, scandir 'un/chemin/vers/static'
    at Object.fs.readdirSync (fs.js:904:18)
    at walk (/var/task/user/index.js:4430:20)
    at module.exports.993.module.exports (/var/task/user/index.js:4496:3)
    at module.exports.432.module.exports (/var/task/user/index.js:1654:2)
    at Module.<anonymous> (/var/task/user/index.js:3297:56801)
    at e (/var/task/user/index.js:3276:124)
    at /var/task/user/index.js:3276:923
    at Object.824 (/var/task/user/index.js:3276:933)
    at __webpack_require__ (/var/task/user/index.js:22:30)
    at Object.138 (/var/task/user/index.js:309:1)
  errno: -2,
  code: 'ENOENT',
  syscall: 'scandir',
  path: 'un/chemin/vers/static' }
```
A priori, je l'ai fixé en simplement créant le dossier `static` manquant. Même si nous n'avons rien dedans actuellement, je l'ajoute donc au versioning avec un fichier `.gitignore`. On s'évite que le build crash lors des premières utilisations du repo.